### PR TITLE
Refine footer design and add GitHub link

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,4 +1,4 @@
-import { Link as ChakraLink, VStack, Heading, Stack, Divider } from '@chakra-ui/react';
+import { Link as ChakraLink, VStack, Text, Stack, Divider } from '@chakra-ui/react';
 import { Link, useLocation } from 'react-router-dom';
 import BitcoinIcon from './bitcoin-icon';
 
@@ -8,14 +8,17 @@ export default function Footer() {
   return (
     <VStack
       fontWeight={900}
-      alignItems="start"
+      alignItems="center"
+      textAlign="center"
       width="100%"
       maxW="1200px"
+      pt={6}
     >
-      <Heading pt={6}>
+      <Divider mb={2} />
+      <Text fontSize="sm" fontWeight="bold">
         News on the ledger of record. <BitcoinIcon color="#F7931A"></BitcoinIcon>
-      </Heading>
-      <Stack direction={['column', 'column', 'row']}>
+      </Text>
+      <Stack direction={['column', 'column', 'row']} align="center">
         {location.pathname !== '/' && (
           <>
             <Link to="/">Home</Link>
@@ -30,6 +33,13 @@ export default function Footer() {
           href="https://inscribe.news"
         >
           Inscribe News
+        </ChakraLink>
+        <Divider orientation="vertical" hideBelow="sm" />
+        <ChakraLink
+          isExternal
+          href="https://github.com/1btc-news/news-client"
+        >
+          GitHub
         </ChakraLink>
       </Stack>
     </VStack>


### PR DESCRIPTION
## Summary
Refines the footer design and adds a repository link, addressing the long-standing footer/link feedback in #21 and #18.

## Changes
- Makes the footer tagline body-sized and bold instead of a large heading.
- Centers the footer content so it reads more clearly as an end-of-article marker.
- Adds a subtle divider above the footer.
- Adds a GitHub link next to the existing Inscribe News link.

## Validation
- `npm run build` ✅

Related: #21, #18
